### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bench-javascript-parser-written-in-rust",
   "version": "1.0.0",
+  "packageManager": "pnpm@11.0.4",
   "private": true,
   "scripts": {
     "table": "node table.mjs"


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates