### PR TITLE
ci: use codspeed mode input

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,4 +36,3 @@ jobs:
         with:
           mode: simulation
           run: cargo codspeed run
-          mode: instrumentation

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Run benchmark
         uses: CodSpeedHQ/action@63f3e98b61959fe67f146a3ff022e4136fe9bb9c # v4.17.6
         with:
-          simulation: true
+          mode: simulation
           run: cargo codspeed run
           mode: instrumentation


### PR DESCRIPTION
Replaces the CodSpeed `simulation` input with `mode: simulation`.