### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2024"
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -16,9 +16,7 @@ trait TheBencher {
     fn bench(g: &mut BenchmarkGroup<'_, WallTime>, path: &Path, source: &str) {
         let cpus = num_cpus::get_physical();
         let id = BenchmarkId::new(Self::ID, "single-thread");
-        g.bench_with_input(id, &source, |b, source| {
-            b.iter(|| Self::parse(path, source))
-        });
+        g.bench_with_input(id, &source, |b, source| b.iter(|| Self::parse(path, source)));
 
         let id = BenchmarkId::new(Self::ID, "no-drop");
         g.bench_with_input(id, &source, |b, source| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,7 @@ pub mod swc {
     pub fn parse(path: &Path, source: &str) -> Module {
         let syntax = match path.extension().unwrap().to_str().unwrap() {
             "js" => Syntax::Es(EsSyntax::default()),
-            "tsx" => Syntax::Typescript(TsSyntax {
-                tsx: true,
-                ..TsSyntax::default()
-            }),
+            "tsx" => Syntax::Typescript(TsSyntax { tsx: true, ..TsSyntax::default() }),
             _ => panic!("need to define syntax for swc"),
         };
         let input = StringInput::new(source, BytePos(0), BytePos(source.len() as u32));


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
